### PR TITLE
Refactor service setup to include configuration options

### DIFF
--- a/01-dhcp.yaml
+++ b/01-dhcp.yaml
@@ -12,6 +12,19 @@
     set_fact:
       dhcp_hosts: "{{ (dhcp_hosts | default([])) + [dhcp_host_template] }}"
     loop: "{{ groups['all'] }}"
+  - name: Build DHCP default range configuration
+    set_fact:
+      dhcp_subnets:
+      - ip: "{{ pakupi_dhcp_network }}"
+        netmask: "{{ pakupi_dhcp_netmask }}"
+        range_begin: "{{ pakupi_dhcp_range.begin }}"
+        range_end: "{{ pakupi_dhcp_range.end }}"
+        domain_name_servers: "{{ pakupi_dhcp_dns }}"
+        # TODO Check and set routers if gateway set
+        # routers: "{{ pakupi_dhcp_gateway }}"
+  - name: DBG
+    debug:
+      msg: "{{ dhcp_subnets }}"
   - name: Setup DHCP server
     include_role:
       name: bertvv.dhcp
@@ -20,13 +33,5 @@
       name: "{{ item }}"
       mac: "{{ hostvars[item].ansible_default_ipv4.macaddress | default(hostvars[item].macaddress) }}"
       ip: "{{ hostvars[item].ansible_host }}"
-      hostname: "{{ item }}.mocha.local"
-    dhcp_subnets:
-    - ip: 192.168.64.0
-      netmask: 255.255.255.0
-      range_begin: 192.168.64.64
-      range_end: 192.168.64.127
-      domain_name_servers:
-      - 8.8.8.8
-      - 8.8.4.4
-      # routers: 192.168.64.2
+      hostname: "{{ item }}.{{ pakupi_domain }}"
+

--- a/02-nis.yaml
+++ b/02-nis.yaml
@@ -1,4 +1,9 @@
 ---
+- hosts: all
+  tasks:
+  - set_fact:
+      nis_domain: "{{ pakupi_nis_domain }}"
+      nis_master: "{{ pakupi_nis_master }}"
 - hosts: mocha-master
   become: yes
   tasks:
@@ -7,7 +12,6 @@
       name: nis
   vars: 
     nis_role: "master"
-    nis_domain: "nis.mocha.local"
 
 - hosts: mocha-worker
   become: yes
@@ -17,6 +21,4 @@
       name: nis
   vars: 
     nis_role: "client"
-    nis_master: "192.168.64.1"
-    nis_domain: "nis.mocha.local"
 

--- a/03-slurm.yaml
+++ b/03-slurm.yaml
@@ -1,4 +1,40 @@
 ---
+- hosts: 
+  - mocha-master
+  - mocha-worker
+  gather_facts: yes
+  tasks:
+  - name: "Set hostname to {{ inventory_hostname }}"
+    become: yes
+    ansible.builtin.hostname:
+      name: "{{ inventory_hostname }}"
+      use: systemd
+  - name: Build Slurm user information
+    set_fact:
+      slurm_user:
+        uid: "{{ hostvars[groups['mocha-master']|first].ansible_user_uid }}"
+        gid: "{{ hostvars[groups['mocha-master']|first].ansible_user_gid }}"
+        name: "{{ hostvars[groups['mocha-master']|first].ansible_user }}"
+        group: "{{ hostvars[groups['mocha-master']|first].ansible_user }}"
+      slurm_create_user: no
+      slurm_create_dirs: yes
+      slurm_nodes: "{{ slurm_nodes }}"
+      slurm_partitions: "{{ slurm_partitions }}"
+      slurm_config:
+        SlurmctldHost: "{{ hostvars[groups['mocha-master']|first].inventory_hostname }}"
+        SlurmctldLogFile: "/var/log/slurm/slurmctld.log"
+        SlurmdSpoolDir: "/var/lib/slurm/slurmd"
+        SlurmdLogFile: "/var/log/slurm/slurmd.log"
+        SlurmctldPidFile: "/var/run/slurm/slurmctld.pid"
+        SlurmdPidFile: "/var/run/slurm/slurmd.pid"
+        StateSaveLocation: "/var/lib/slurm/slurmctld"
+        ReturnToService: 2
+      slurm_munge_key: "./files/munge.key"
+      slurm_config_dir: "/etc/slurm"
+  vars:
+    slurm_partitions: "{{ lookup('template', 'slurm_partitions.yml.j2') }}"
+    slurm_nodes: "{{ lookup('template', 'slurm_nodes.yml.j2') }}"
+      
 - hosts: mocha-master
   become: yes
   tasks:
@@ -18,32 +54,6 @@
       state: started
   vars: 
     slurm_roles: ["controller"]
-    slurm_create_user: no
-    slurm_create_dirs: yes
-    slurm_user:
-      comment: "Slurm Workload Manager"
-      gid: 1000
-      group: user
-      name: user
-      uid: 1000
-    slurm_nodes:
-    - name: "mocha-worker"
-      CoresPerSocket: 1
-      Sockets: 1
-      ThreadsPerCore: 1
-    slurm_partitions:
-    - name: pi
-      Default: YES
-      MaxTime: UNLIMITED
-      Nodes: "mocha-worker"
-    slurm_config:
-      SlurmctldHost: "mocha-master"
-      SlurmctldLogFile: "/var/log/slurm/slurmctld.log"
-      SlurmdSpoolDir: "/var/lib/slurm/slurmd"
-      SlurmdLogFile: "/var/log/slurm/slurmd.log"
-      ReturnToService: 2
-    slurm_munge_key: "./files/munge.key"
-    slurm_config_dir: "/etc/slurm"
 
 - hosts: mocha-worker
   become: yes
@@ -71,29 +81,3 @@
       state: started
   vars:
     slurm_roles: ["exec"]
-    slurm_create_user: no
-    slurm_create_dirs: yes
-    slurm_user:
-      comment: "Slurm Workload Manager"
-      gid: 1000
-      group: user
-      name: user
-      uid: 1000
-    slurm_nodes:
-    - name: "mocha-worker"
-      CoresPerSocket: 1
-      Sockets: 1
-      ThreadsPerCore: 1
-    slurm_partitions:
-    - name: pi
-      Default: YES
-      MaxTime: UNLIMITED
-      Nodes: "mocha-worker"
-    slurm_config:
-      SlurmctldHost: "mocha-master"
-      SlurmctldLogFile: "/var/log/slurm/slurmctld.log"
-      SlurmdLogFile: "/var/log/slurm/slurmd.log"
-      SlurmdSpoolDir: "/var/lib/slurm/slurmd"
-      ReturnToService: 2
-    slurm_munge_key: "./files/munge.key"
-    slurm_config_dir: "/etc/slurm"

--- a/04-nfs.yaml
+++ b/04-nfs.yaml
@@ -4,7 +4,7 @@
   tasks:
   - name: Create export folder
     file:
-      path: /exports/mocha
+      path: "{{ pakupi_nfs_export }}"
       state: directory
       mode: '0777'
   - name: Setup NFS server
@@ -12,7 +12,7 @@
       name: geerlingguy.nfs
   vars:
     nfs_exports:
-    - "/exports/mocha *(rw,sync,no_root_squash,no_subtree_check)"
+    - "{{ pakupi_nfs_export }} *(rw,sync,no_root_squash,no_subtree_check)"
 - hosts: mocha-worker
   become: yes
   tasks:
@@ -25,6 +25,6 @@
       backup: yes
       fstype: nfs
       opts: "rw,sync,hard"
-      path: "/shared/mocha"
-      src: "mocha-master:/exports/mocha"
+      path: "{{ pakupi_nfs_import }}"
+      src: "{{ hostvars[groups['mocha-master']|first].inventory_hostname }}:{{ pakupi_nfs_export }}"
       state: mounted

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,0 +1,12 @@
+---
+pakupi_domain: "pakupi.local"
+# DHCP Configuration
+pakupi_dhcp_network: 192.168.64.0
+pakupi_dhcp_netmask: 255.255.255.0
+pakupi_dhcp_range:
+  begin: 192.168.64.64
+  end: 192.168.64.127
+pakupi_dhcp_dns:
+- 8.8.8.8
+- 8.8.4.4
+pakupi_dhcp_gateway: 

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -16,6 +16,9 @@ pakupi_nis_master: 192.168.64.1 # TODO Compute from facts
 pakupi_nis_domain: "nis.pakupi.local"
 
 # Slurm Configuration
+pakupi_slurm_partitions:
+- mocha-worker
+- pi3_worker
 
 # NFS Configuration
 pakupi_nfs_export: "/exports/pakupi"

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -9,4 +9,14 @@ pakupi_dhcp_range:
 pakupi_dhcp_dns:
 - 8.8.8.8
 - 8.8.4.4
-pakupi_dhcp_gateway: 
+pakupi_dhcp_gateway: # TODO Implement
+
+# NIS Configuration
+pakupi_nis_master: 192.168.64.1 # TODO Compute from facts
+pakupi_nis_domain: "nis.pakupi.local"
+
+# Slurm Configuration
+
+# NFS Configuration
+pakupi_nfs_export: "/exports/pakupi"
+pakupi_nfs_import: "/shared/pakupi"

--- a/templates/slurm_nodes.yml.j2
+++ b/templates/slurm_nodes.yml.j2
@@ -1,0 +1,15 @@
+[
+
+{% for node in groups["mocha-worker"] %}
+  {% set f = hostvars[node].ansible_facts %}
+  {% set threads_per_core = f.processor_threads_per_core %}
+  {% set cores = f.processor_vcpus / threads_per_core %}
+  {% set cpus = cores / f.processor_nproc %}
+  {
+    "name": "{{ node }}",
+    "CoresPerSocket": "{{ (cores/cpus)|int }}",
+    "Sockets": "{{ cpus|int }}",
+    "ThreadsPerCore": "{{ threads_per_core }}",
+  },
+{% endfor %}
+]

--- a/templates/slurm_partitions.yml.j2
+++ b/templates/slurm_partitions.yml.j2
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "mocha-worker",
+    "Default": "YES",
+    "MaxTime": "UNLIMITED",
+    "Nodes": "ALL",
+  },
+  {% for partition in pakupi_slurm_partitions %}
+    {% if partition != "mocha-worker" %}
+    {
+    "name": "{{ partition }}",
+    "Default": "NO",
+    "MaxTime": "UNLIMITED",
+    "Nodes": "{{ ",".join(groups[partition]) }}",
+  },
+    {% endif %}
+  {% endfor %} 
+]


### PR DESCRIPTION
The service setups have been refactored to:
- expose configuration options for the different services, e.g. NIS domain, DHCP default range...
- generate additional configuration from available facts, e.g. Slurm node list

Closes #7